### PR TITLE
💡 [fix] : 일기 배경사진 저장 수정 

### DIFF
--- a/src/main/java/com/CSE/KLAB/diary/Diary.java
+++ b/src/main/java/com/CSE/KLAB/diary/Diary.java
@@ -26,6 +26,10 @@ public class Diary {
     @JoinColumn(name = "user_id")
     private Member member;
 
+
     private String content;
+
+    @Column(name = "background_image_idx")
+    private int backgroundImageIdx;
 
 }

--- a/src/main/java/com/CSE/KLAB/diary/DiaryRequestDto.java
+++ b/src/main/java/com/CSE/KLAB/diary/DiaryRequestDto.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class DiaryRequestDto {
     private Long userId;
     private String content;
+    private int backgroundImageIdx;
 }

--- a/src/main/java/com/CSE/KLAB/diary/DiaryResponseDto.java
+++ b/src/main/java/com/CSE/KLAB/diary/DiaryResponseDto.java
@@ -9,4 +9,5 @@ public class DiaryResponseDto {
     private Long diaryId;
     private Long userId;
     private String content;
+    private int backgroundImageIdx;
 }

--- a/src/main/java/com/CSE/KLAB/diary/DiaryService.java
+++ b/src/main/java/com/CSE/KLAB/diary/DiaryService.java
@@ -23,6 +23,7 @@ public class DiaryService {
         Diary diary = new Diary();
         diary.setMember(member);
         diary.setContent(requestDto.getContent());
+        diary.setBackgroundImageIdx(requestDto.getBackgroundImageIdx());
 
         Diary savedDiary = diaryRepository.save(diary);
 
@@ -30,9 +31,11 @@ public class DiaryService {
         responseDto.setDiaryId(savedDiary.getDiaryId());
         responseDto.setUserId(savedDiary.getMember().getUserId());
         responseDto.setContent(savedDiary.getContent());
+        responseDto.setBackgroundImageIdx(savedDiary.getBackgroundImageIdx());
 
         return responseDto;
     }
+
     @Transactional
     public DiaryResponseDto getDiary(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
@@ -42,25 +45,31 @@ public class DiaryService {
         responseDto.setDiaryId(diary.getDiaryId());
         responseDto.setUserId(diary.getMember().getUserId());
         responseDto.setContent(diary.getContent());
+        responseDto.setBackgroundImageIdx(diary.getBackgroundImageIdx());
 
         return responseDto;
     }
+
     @Transactional
     public DiaryResponseDto updateDiary(Long diaryId, DiaryUpdateRequestDto requestDto) {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new IllegalArgumentException("Diary not found with id: " + diaryId));
 
         diary.setContent(requestDto.getContent());
+        diary.setBackgroundImageIdx(requestDto.getBackgroundImageIdx());
+
         Diary updatedDiary = diaryRepository.save(diary);
 
         DiaryResponseDto responseDto = new DiaryResponseDto();
         responseDto.setDiaryId(updatedDiary.getDiaryId());
         responseDto.setUserId(updatedDiary.getMember().getUserId());
         responseDto.setContent(updatedDiary.getContent());
+        responseDto.setBackgroundImageIdx(updatedDiary.getBackgroundImageIdx());
 
         return responseDto;
     }
 
+    @Transactional
     public List<DiaryResponseDto> getDiariesByUserId(Long userId) {
         List<Diary> diaries = diaryRepository.findByMemberUserId(userId);
 
@@ -69,6 +78,7 @@ public class DiaryService {
             responseDto.setDiaryId(diary.getDiaryId());
             responseDto.setUserId(diary.getMember().getUserId());
             responseDto.setContent(diary.getContent());
+            responseDto.setBackgroundImageIdx(diary.getBackgroundImageIdx());
             return responseDto;
         }).collect(Collectors.toList());
     }

--- a/src/main/java/com/CSE/KLAB/diary/DiaryUpdateRequestDto.java
+++ b/src/main/java/com/CSE/KLAB/diary/DiaryUpdateRequestDto.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 @Setter
 public class DiaryUpdateRequestDto {
     private String content;
+    private int backgroundImageIdx;
 }


### PR DESCRIPTION
일기 엔티티에 idx값을 저장하도록 하여, 프론트에서 asset에 담긴 idx 값을 저장할수 있도록 수정하였습니다.

## 🔘Part

- [X] BE

  <br/>

## 🔎 작업 내용

- 프론트 정빈님이 요청한 asset에 담긴 이미지를 저장하기 위하여 idx 값을 저장하면 좋겠다 라는 요청이 있어서 
- 해당 idx 값을 저장하도록 엔티티와 이에 수반되는 기능들에 전부 적용시켰습니다.

  <br/>

## 이미지 첨부

![image](https://github.com/K-LAB-CSE/K-LAB-SERVER/assets/58305106/4cdf8477-ac37-489f-bb9b-d918218fa300)

<br/>

## 🔧 앞으로의 과제

- 기 배포가 완료된 서버 기능을 바탕으로 api 연결된 기능들에서 추후 프론트요청사항과 유지보수 기간을 가질 예정입니다.


  <br/>


<br/>