### PR TITLE
💡 feat :  일기 생성 방식 수정

### DIFF
--- a/src/main/java/com/CSE/KLAB/DiaryGenerate/Configuration/GPTController.java
+++ b/src/main/java/com/CSE/KLAB/DiaryGenerate/Configuration/GPTController.java
@@ -30,26 +30,34 @@ public class GPTController {
             @RequestParam String userInput,
             @RequestParam String todayDate) {
 
-        // 일기 생성 프롬프트 초기화
-        StringBuilder promptBuilder = new StringBuilder();
-        promptBuilder.append("This system is ai auto writing diary\n");
-        promptBuilder.append("Written person name is ").append(username).append(", write name at the end of diary.\n");
-        promptBuilder.append("I want you to write diary with information ").append(userInput).append("\n");
-//        promptBuilder.append("okay is there any information i need to know?\n");
-        promptBuilder.append("Also, write down date with information, ").append(todayDate).append("\n");
-//        promptBuilder.append("okay is there any information i need to know?\n");
-        promptBuilder.append("In the diary, change lines every 20 words.\n");
-        promptBuilder.append("And be sure to return the diary you generate in Korean language only.\n");
-//        promptBuilder.append("okay is there any information i need to know?\n");
+        // 첫 번째 프롬프트: 일기 생성
+        StringBuilder promptBuilder1 = new StringBuilder();
+        promptBuilder1.append("This system is ai auto writing diary\n");
+        promptBuilder1.append("Written person name is ").append(username).append(", write name at the end of diary.\n");
+        promptBuilder1.append("I want you to write diary with information ").append(userInput).append("\n");
+        promptBuilder1.append("Also, write down date with information, ").append(todayDate).append("\n");
+        promptBuilder1.append("In the diary, change lines every 20 words.\n");
 
-        GPTRequest gptRequest = new GPTRequest(
-                model, promptBuilder.toString(), 1, 256, 1, 2, 2);
+        GPTRequest gptRequest1 = new GPTRequest(
+                model, promptBuilder1.toString(), 1, 256, 1, 2, 2);
 
-        GPTResponse gptResponse = restTemplate.postForObject(
-                apiUrl, gptRequest, GPTResponse.class);
+        GPTResponse gptResponse1 = restTemplate.postForObject(
+                apiUrl, gptRequest1, GPTResponse.class);
 
+        String diaryContent = gptResponse1.getChoices().get(0).getMessage().getContent();
 
-        return gptResponse.getChoices().get(0).getMessage().getContent();
+        // 두 번째 프롬프트: 일기 번역
+        StringBuilder promptBuilder2 = new StringBuilder();
+        promptBuilder2.append("Translate this diary in korean language\n");
+        promptBuilder2.append(diaryContent);
+
+        GPTRequest gptRequest2 = new GPTRequest(
+                model, promptBuilder2.toString(), 1, 256, 1, 2, 2);
+
+        GPTResponse gptResponse2 = restTemplate.postForObject(
+                apiUrl, gptRequest2, GPTResponse.class);
+
+        return gptResponse2.getChoices().get(0).getMessage().getContent();
     }
 
     // 네덜란드어 일기 생성 컨트롤러
@@ -60,24 +68,34 @@ public class GPTController {
             @RequestParam String todayDate) {
 
         // 일기 생성 프롬프트 초기화
-        StringBuilder promptBuilder = new StringBuilder();
-        promptBuilder.append("This system is ai auto writing diary\n");
-        promptBuilder.append("Written person name is ").append(username).append(", write name at the end of diary.\n");
-        promptBuilder.append("I want you to write diary with information ").append(userInput).append("\n");
+        StringBuilder promptBuilder1 = new StringBuilder();
+        promptBuilder1.append("This system is ai auto writing diary\n");
+        promptBuilder1.append("Written person name is ").append(username).append(", write name at the end of diary.\n");
+        promptBuilder1.append("I want you to write diary with information ").append(userInput).append("\n");
 //        promptBuilder.append("okay is there any information i need to know?\n");
-        promptBuilder.append("Also, write down date with information, ").append(todayDate).append("\n");
+        promptBuilder1.append("Also, write down date with information, ").append(todayDate).append("\n");
 //        promptBuilder.append("okay is there any information i need to know?\n");
-        promptBuilder.append("In the diary, change lines every 20 words.\n");
-        promptBuilder.append("And be sure to return the diary you generate in dutch language only.\n");
-//        promptBuilder.append("okay is there any information i need to know?\n");
+        promptBuilder1.append("In the diary, change lines every 20 words.\n");
 
-        GPTRequest gptRequest = new GPTRequest(
-                model, promptBuilder.toString(), 1, 256, 1, 2, 2);
+        GPTRequest gptRequest1 = new GPTRequest(
+                model, promptBuilder1.toString(), 1, 256, 1, 2, 2);
 
-        GPTResponse gptResponse = restTemplate.postForObject(
-                apiUrl, gptRequest, GPTResponse.class);
+        GPTResponse gptResponse1 = restTemplate.postForObject(
+                apiUrl, gptRequest1, GPTResponse.class);
 
+        String diaryContent = gptResponse1.getChoices().get(0).getMessage().getContent();
 
-        return gptResponse.getChoices().get(0).getMessage().getContent();
+        // 두 번째 프롬프트: 일기 번역
+        StringBuilder promptBuilder2 = new StringBuilder();
+        promptBuilder2.append("Translate this diary in dutch language\n");
+        promptBuilder2.append(diaryContent);
+
+        GPTRequest gptRequest2 = new GPTRequest(
+                model, promptBuilder2.toString(), 1, 256, 1, 2, 2);
+
+        GPTResponse gptResponse2 = restTemplate.postForObject(
+                apiUrl, gptRequest2, GPTResponse.class);
+
+        return gptResponse2.getChoices().get(0).getMessage().getContent();
     }
 }

--- a/src/main/java/com/CSE/KLAB/member/MemberController.java
+++ b/src/main/java/com/CSE/KLAB/member/MemberController.java
@@ -27,4 +27,9 @@ public class MemberController {
         MemberResponseDto responseDto = memberService.getMember(userId);
         return new BaseResponse<>(responseDto);
     }
+    @GetMapping("/name/{name}")
+    public BaseResponse<MemberResponseDto> getMemberByName(@PathVariable String name) {
+        MemberResponseDto responseDto = memberService.getMemberByName(name);
+        return new BaseResponse<>(responseDto);
+    }
 }

--- a/src/main/java/com/CSE/KLAB/member/MemberRepository.java
+++ b/src/main/java/com/CSE/KLAB/member/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.CSE.KLAB.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByName(String name);
 }

--- a/src/main/java/com/CSE/KLAB/member/MemberService.java
+++ b/src/main/java/com/CSE/KLAB/member/MemberService.java
@@ -42,4 +42,16 @@ public class MemberService {
 
         return responseDto;
     }
+    public MemberResponseDto getMemberByName(String name) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found with name: " + name));
+
+        MemberResponseDto responseDto = new MemberResponseDto();
+        responseDto.setUserId(member.getUserId());
+        responseDto.setName(member.getName());
+        responseDto.setIntroduce(member.getIntroduce());
+        responseDto.setProfileImage(member.getProfileImage());
+
+        return responseDto;
+    }
 }


### PR DESCRIPTION
- 제목 : feat(#4 ): 기능명


## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- PathVariable 로 기존에는 PK 값으로 바로 사용자를 조회하였다면, Member 의 name 으로 조회하는 기능으로 수정하였습니다.
- 기존에는 일기 생성시 키워드로 입력하여 바로 일기생성후, 번역까지 하나의 context로 보냈다면, 두번의 context로 나누었습니다.
  <br/>

## 이미지 첨부

![image](https://github.com/K-LAB-CSE/K-LAB-SERVER/assets/58305106/3dad4d3f-af53-4f19-b995-eeb9f99a6569)


<br/>

## 🔧 앞으로의 과제

추가 요청사항에 따라 수정할 예정입니다 ! 

  <br/>

## ➕ 이슈 링크

- [해당 이슈 #4 ](#4 )

<br/>